### PR TITLE
kill handrolled stuff in api class

### DIFF
--- a/coveralls-ruby.gemspec
+++ b/coveralls-ruby.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'thor', '~> 0.19.4'
   gem.add_dependency 'tins', '~> 1.6'
 
-  gem.add_development_dependency 'bundler', '~> 1.7'
+  gem.add_development_dependency 'bundler', '>= 1.7'
 end

--- a/coveralls-ruby.gemspec
+++ b/coveralls-ruby.gemspec
@@ -19,11 +19,12 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 1.8.7'
 
+  gem.add_dependency 'httparty', '~> 0.16.2'
   gem.add_dependency 'json', '>= 1.8', '< 3'
   gem.add_dependency 'simplecov', '~> 0.16.1'
-  gem.add_dependency 'tins', '~> 1.6'
   gem.add_dependency 'term-ansicolor', '~> 1.3'
   gem.add_dependency 'thor', '~> 0.19.4'
+  gem.add_dependency 'tins', '~> 1.6'
 
   gem.add_development_dependency 'bundler', '~> 1.7'
 end

--- a/lib/coveralls/api.rb
+++ b/lib/coveralls/api.rb
@@ -1,5 +1,5 @@
 require 'json'
-require 'net/https'
+require 'httparty'
 require 'tempfile'
 
 module Coveralls
@@ -18,24 +18,29 @@ module Coveralls
     def self.post_json(endpoint, hash)
       disable_net_blockers!
 
-      uri = endpoint_to_uri(endpoint)
-
       Coveralls::Output.puts("#{ JSON.pretty_generate(hash) }", :color => "green") if ENV['COVERALLS_DEBUG']
       Coveralls::Output.puts("[Coveralls] Submitting to #{API_BASE}", :color => "cyan")
 
-      client  = build_client(uri)
-      request = build_request(uri.path, hash)
+      url = endpoint_to_url(endpoint)
+      hash = apified_hash(hash)
 
-      response = client.request(request)
+      response = HTTParty.post(
+        url,
+        body: {
+          json_file: hash_to_file(hash),
+        },
+      )
 
-      response_hash = JSON.load(response.body.to_str)
-
-      if response_hash['message']
-        Coveralls::Output.puts("[Coveralls] #{ response_hash['message'] }", :color => "cyan")
+      if response['message']
+        Coveralls::Output.puts("[Coveralls] #{ response['message'] }", :color => "cyan")
       end
 
-      if response_hash['url']
-        Coveralls::Output.puts("[Coveralls] #{ Coveralls::Output.format(response_hash['url'], :color => "underline") }", :color => "cyan")
+      if response['url']
+        Coveralls::Output.puts("[Coveralls] #{ Coveralls::Output.format(response['url'], :color => "underline") }", :color => "cyan")
+      end
+
+      if response['error']
+        Coveralls::Output.puts("[Coveralls] Error: #{ Coveralls::Output.format(response['error'], :color => "underline") }", :color => "red")
       end
 
       case response
@@ -67,55 +72,20 @@ module Coveralls
       end
     end
 
-    def self.endpoint_to_uri(endpoint)
-      URI.parse("#{API_BASE}/#{endpoint}")
-    end
-
-    def self.build_client(uri)
-      client = Net::HTTP.new(uri.host, uri.port)
-      client.use_ssl = true if uri.port == 443
-      client.verify_mode = OpenSSL::SSL::VERIFY_NONE
-
-      unless client.respond_to?(:ssl_version=)
-        Net::HTTP.ssl_context_accessor("ssl_version")
-      end
-
-      client.ssl_version = 'TLSv1'
-
-      client
-    end
-
-    def self.build_request(path, hash)
-      request  = Net::HTTP::Post.new(path)
-      boundary = rand(1_000_000).to_s
-
-      request.body         = build_request_body(hash, boundary)
-      request.content_type = "multipart/form-data, boundary=#{boundary}"
-
-      request
-    end
-
-    def self.build_request_body(hash, boundary)
-      hash = apified_hash(hash)
-      file = hash_to_file(hash)
-
-      "--#{boundary}\r\n" \
-      "Content-Disposition: form-data; name=\"json_file\"; filename=\"#{File.basename(file.path)}\"\r\n" \
-      "Content-Type: text/plain\r\n\r\n" +
-      File.read(file.path) +
-      "\r\n--#{boundary}--\r\n"
+    def self.endpoint_to_url(endpoint)
+      "#{API_BASE}/#{endpoint}"
     end
 
     def self.hash_to_file(hash)
       file = nil
       Tempfile.open(['coveralls-upload', 'json']) do |f|
-        f.write(JSON.dump hash)
+        f.write(hash.to_json)
         file = f
       end
       File.new(file.path, 'rb')
     end
 
-    def self.apified_hash hash
+    def self.apified_hash(hash)
       config = Coveralls::Configuration.configuration
       if ENV['COVERALLS_DEBUG'] || Coveralls.testing
         Coveralls::Output.puts "[Coveralls] Submitting with config:", :color => "yellow"

--- a/lib/coveralls/version.rb
+++ b/lib/coveralls/version.rb
@@ -1,3 +1,3 @@
 module Coveralls
- VERSION = "0.8.22"
+ VERSION = "0.8.24"
 end


### PR DESCRIPTION
In case we ever need this fix in the `coveralls-revelry` gem